### PR TITLE
Autofix file names and add jpg Title tag

### DIFF
--- a/action_anteater.php
+++ b/action_anteater.php
@@ -239,9 +239,10 @@ class action_plugin_preservefilenames_anteater extends DokuWiki_Action_Plugin
      */
     function _replaceLinkURL(&$event)
     {
-        if ($event->data[0] !== 'xhtml') {
-            return;
-        }
+        // MI: allow also dw2PDF
+        //if ($event->data[0] !== 'xhtml') {
+        //    return;
+        //}
 
         // image link
         $event->data[1] = preg_replace_callback(


### PR DESCRIPTION
These are my changes which helped me in my Dokuwiki case.
When files are listed in media manager:
- files with invalid names are fixed
- jpg Iptc.Headline tag is set from
  - descript.ion file if present in a folder - always
  - file name without extension - only if the tag is not set yet
    While using DWToPDF plugin, I had to make a change to allow proper behaviour of this plugin.

Thank You for this useful plugin.
